### PR TITLE
Change "id" to "uuid"

### DIFF
--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -488,7 +488,7 @@ class TestLibrary(BaseClient):
 
         # Create the :class:`sciunit.Test` instance
         test_instance = test_cls(observation=observations, **params)
-        test_instance.id = test_instance_json["id"]  # this is just the path part. Should be a full url
+        test_instance.uuid = test_instance_json["id"]
         return test_instance
 
     def list_tests(self, **filters):
@@ -1134,9 +1134,9 @@ class TestLibrary(BaseClient):
 
         if not hasattr(test_result.model, "instance_id"):
             # check that the model is registered with the model registry.
-            if not hasattr(test_result.model, "id"):
-                raise AttributeError("Model class does not have an 'id' attribute. "
-                                     "Please register it with the Validation Framework and add the id to the code.")
+            if not hasattr(test_result.model, "uuid"):
+                raise AttributeError("Model class does not have a 'uuid' attribute. "
+                                     "Please register it with the Validation Framework and add the uuid to the code.")
             if not hasattr(test_result.model, "version"):
                 raise AttributeError("Model class does not have a 'version' attribute")
             model_catalog = ModelCatalog.from_existing(self)
@@ -1145,7 +1145,7 @@ class TestLibrary(BaseClient):
                                                                      version=test_result.model.version)['id']
             except Exception:  # probably the instance doesn't exist (todo: distinguish from other reasons for Exception)
                 # so we create an new instance
-                response = model_catalog.add_model_instance(model_id=test_result.model.id,
+                response = model_catalog.add_model_instance(model_id=test_result.model.uuid,
                                                             source=getattr(test_result.model, "remote_url", ""),
                                                             version=test_result.model.version,
                                                             parameters=getattr(test_result.model, "parameters", ""))
@@ -1176,7 +1176,7 @@ class TestLibrary(BaseClient):
         url = self.url + "/results/?format=json"
         result_json = {
                         "model_version_id": model_instance_id,
-                        "test_code_id": test_result.test.id,
+                        "test_code_id": test_result.test.uuid,
                         "results_storage": results_storage,
                         "score": test_result.score,
                         "passed": None if "passed" not in test_result.related_data else test_result.related_data["passed"],

--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -1180,8 +1180,11 @@ class TestLibrary(BaseClient):
         headers = {'Content-type': 'application/json'}
         response = requests.post(url, data=json.dumps([result_json]),
                                  auth=self.auth, headers=headers)
-        print("Result registered successfully!")
-        return response.json()["uuid"][0]
+        if response.status_code == 201:
+            print("Result registered successfully!")
+            return response.json()["uuid"][0]
+        else:
+            raise Exception(response.content)
 
     def _get_platform(self):
         """

--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -263,6 +263,15 @@ class BaseClient(object):
                 raise Exception("Downloading of resources currently supported only for files and folders!")
         return files_downloaded
 
+    @classmethod
+    def from_existing(cls, client):
+        """Used to easily create a TestLibrary if you already have a ModelCatalog, or vice versa"""
+        obj = cls.__new__(cls)
+        for attrname in ("username", "url", "client_id", "token", "verify", "auth"):
+            setattr(obj, attrname, getattr(client, attrname))
+        return obj
+
+
 class TestLibrary(BaseClient):
     """Client for the HBP Validation Test library.
 

--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -151,6 +151,8 @@ class BaseClient(object):
                 url = rNMPI1.headers.get('location')
             else:
                 res = rNMPI1.content
+                if not isinstance(res, str):
+                    res = res.decode("ascii")
                 state = res[res.find("state")+6:res.find("&redirect_uri")]
                 url = "https://services.humanbrainproject.eu/oidc/authorize?state={}&redirect_uri={}/complete/hbp/&response_type=code&client_id={}".format(state, self.url, self.client_id)
             # get the exchange cookie

--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -1087,7 +1087,7 @@ class TestLibrary(BaseClient):
         result_json = result_json.json()
         return result_json
 
-    def register_result(self, test_result, data_store=None):
+    def register_result(self, test_result, data_store=None, project=None):
         """Register test result with HBP Validation Results Service.
 
         The score of a test, along with related output data such as figures,
@@ -1126,6 +1126,11 @@ class TestLibrary(BaseClient):
         # depending on value of data_store,
         # upload data file to Collab storage,
         # or just store path if it is on HPAC machine
+
+        if project is None:
+            project = test_result.related_data.get("project", None)
+        if project is None:
+            raise Exception("Don't know where to register this result. Please specify the collab ID")
 
         if not hasattr(test_result.model, "instance_id"):
             # check that the model is registered with the model registry.
@@ -1167,7 +1172,7 @@ class TestLibrary(BaseClient):
                         "score": test_result.score,
                         "passed": None if "passed" not in test_result.related_data else test_result.related_data["passed"],
                         "platform": str(self._get_platform()), # database accepts a string
-                        "project": test_result.related_data["project"],
+                        "project": project,
                         "normalized_score": test_result.score
                       }
 

--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -1087,7 +1087,7 @@ class TestLibrary(BaseClient):
         result_json = result_json.json()
         return result_json
 
-    def register_result(self, test_result="", data_store=None):
+    def register_result(self, test_result, data_store=None):
         """Register test result with HBP Validation Results Service.
 
         The score of a test, along with related output data such as figures,
@@ -1126,6 +1126,28 @@ class TestLibrary(BaseClient):
         # depending on value of data_store,
         # upload data file to Collab storage,
         # or just store path if it is on HPAC machine
+
+        if not hasattr(test_result.model, "instance_id"):
+            # check that the model is registered with the model registry.
+            if not hasattr(test_result.model, "id"):
+                raise AttributeError("Model class does not have an 'id' attribute. "
+                                     "Please register it with the Validation Framework and add the id to the code.")
+            if not hasattr(test_result.model, "version"):
+                raise AttributeError("Model class does not have a 'version' attribute")
+            model_catalog = ModelCatalog.from_existing(self)
+            try:
+                model_instance_id = model_catalog.get_model_instance(model_id=test_result.model.uuid,
+                                                                     version=test_result.model.version)['id']
+            except Exception:  # probably the instance doesn't exist (todo: distinguish from other reasons for Exception)
+                # so we create an new instance
+                response = model_catalog.add_model_instance(model_id=test_result.model.id,
+                                                            source=getattr(test_result.model, "remote_url", ""),
+                                                            version=test_result.model.version,
+                                                            parameters=getattr(test_result.model, "parameters", ""))
+                model_instance_id = response['uuid']
+        else:
+            model_instance_id = test_result.model.instance_id
+
         if data_store:
             if not data_store.authorized:
                 data_store.authorize(self.auth)  # relies on data store using HBP authorization
@@ -1137,11 +1159,9 @@ class TestLibrary(BaseClient):
         else:
             results_storage = ""
 
-        # check that the model is registered with the model registry.
-        # If not, offer to register it?
         url = self.url + "/results/?format=json"
         result_json = {
-                        "model_version_id": test_result.model.instance_id,
+                        "model_version_id": model_instance_id,
                         "test_code_id": test_result.test.id,
                         "results_storage": results_storage,
                         "score": test_result.score,

--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -453,6 +453,8 @@ class TestLibrary(BaseClient):
 
         # Transform string representations of quantities, e.g. "-65 mV",
         # into :class:`quantities.Quantity` objects.
+
+        # note: we shouldn't really do this here; this should be done in the test classes
         observations = {}
         if type(observation_data.values()[0]) is dict:
             observations = observation_data
@@ -465,9 +467,13 @@ class TestLibrary(BaseClient):
                         observations[key] = float(val)
                     except ValueError:
                         quantity_parts = val.split(" ")
-                        number = float(quantity_parts[0])
-                        units = " ".join(quantity_parts[1:])
-                        observations[key] = quantities.Quantity(number, units)
+                        try:
+                            number = float(quantity_parts[0])
+                        except ValueError:
+                            observations[key] = val
+                        else:
+                            units = " ".join(quantity_parts[1:])
+                            observations[key] = quantities.Quantity(number, units)
 
         # Create the :class:`sciunit.Test` instance
         test_instance = test_cls(observation=observations, **params)

--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -1160,7 +1160,16 @@ class TestLibrary(BaseClient):
                                                  # the data store before passing to `register()`
             if data_store.collab_id is None:
                 data_store.collab_id = project
-            results_storage = data_store.upload_data(test_result.related_data["figures"])
+            files_to_upload = []
+            if "figures" in test_result.related_data:
+                files_to_upload.extend(test_result.related_data["figures"])
+            if not files_to_upload:
+                # workaround for https://github.com/joffreygonin/hbp-validation-framework_dev/issues/136
+                if not os.path.exists("related_data.txt"):
+                    with open("related_data.txt", "w") as fp:
+                        fp.write("This validation test did not produce any additional data")
+                files_to_upload = ["related_data.txt"]
+            results_storage = data_store.upload_data(files_to_upload)
         else:
             results_storage = ""
 

--- a/hbp_validation_framework/datastores.py
+++ b/hbp_validation_framework/datastores.py
@@ -35,7 +35,7 @@ class FileSystemDataStore(object):
     A class for interacting with the local file system
     """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         pass
 
     def load_data(self, local_path):
@@ -48,7 +48,7 @@ class CollabDataStore(object):
     A class for uploading data to HBP Collaboratory storage.
     """
 
-    def __init__(self, collab_id=None, base_folder=None, auth=None):
+    def __init__(self, collab_id=None, base_folder=None, auth=None, **kwargs):
         self.collab_id = collab_id
         self.base_folder = base_folder
         self._auth = auth  # we defer authorization until needed
@@ -152,6 +152,9 @@ class HTTPDataStore(object):
     """
     A class for downloading data from the web.
     """
+
+    def __init__(self, **kwargs):
+        pass
 
     def upload_data(self, file_paths):
         raise NotImplementedError("The HTTPDataStore does not support uploading data.")


### PR DESCRIPTION
The master branch of sciunit now defines a read-only attribute `id` for all classes. We therefore need to use something else for identifying models and tests, I am proposing `uuid`.

All `sciunit.Model` classes registered with the Validation service will need to be updated, unfortunately.
