### PR TITLE
Updates model edit to require only input of updated fields

### DIFF
--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -1958,7 +1958,7 @@ class ModelCatalog(BaseClient):
         else:
             raise Exception("Error in adding model instance. Response = " + str(response.json()))
 
-    def edit_model_instance(self, instance_id=None, model_id=None, alias=None, source=None, version=None, description=None, parameters=None):
+    def edit_model_instance(self, instance_id="", model_id="", alias="", source=None, version=None, description=None, parameters=None):
         """Edit an existing model instance.
 
         This allows to edit an instance of an existing model in the model catalog.

--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -1705,6 +1705,8 @@ class ModelCatalog(BaseClient):
                 model_data[key] = model_json[key]
         if app_id is None:
             app_id = model_json["app"]["id"]
+        if model_data["alias"] == "":
+            model_data["alias"] = None
 
         values = self.get_attribute_options()
 


### PR DESCRIPTION
Fixes #13 
`edit_model()` now requires only input of updated fields (previously all fields had to be specified)