### PR TITLE
Change version to model_version in find_model_instance_else_add() to avoid SciUnit overlap

### DIFF
--- a/hbp_validation_framework/__init__.py
+++ b/hbp_validation_framework/__init__.py
@@ -2065,12 +2065,12 @@ class ModelCatalog(BaseClient):
                 raise AttributeError("Model object does not have a 'version' attribute")
             try:
                 model_instance_uuid = self.get_model_instance(model_id=model_obj.model_uuid,
-                                                                     version=model_obj.version)['id']
+                                                                     version=model_obj.model_version)['id']
             except Exception:  # probably the instance doesn't exist (todo: distinguish from other reasons for Exception)
                 # so we create a new instance
                 response = self.add_model_instance(model_id=model_obj.model_uuid,
                                                             source=getattr(model_obj, "remote_url", ""),
-                                                            version=model_obj.version,
+                                                            version=model_obj.model_version,
                                                             parameters=getattr(model_obj, "parameters", ""))
                 model_instance_uuid = response['uuid'][0]
         else:


### PR DESCRIPTION
SciUnit now internally uses the parameter `version`.
So I have now renamed the validation framework parameter  from `version` to `model_version` in the method `find_model_instance_else_add()`.