### PR TITLE
fix for pickling NEURON based models

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ template_files = package_files('hbp_validation_framework', 'templates')
 
 setup(
     name='hbp_validation_framework',
-    version='0.6.2',
+    version='0.6.3',
     packages=['hbp_validation_framework'],
     package_data={'': json_files+template_files},
     url='https://github.com/HumanBrainProject/hbp-validation-client',


### PR DESCRIPTION
removes unpickelable model bits from the SciUnit scores object